### PR TITLE
Case Insensitive Command Dispatching

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -24,6 +24,16 @@ namespace cppsh {
     std::string read_input();
 
     /**
+     * @brief Compares two std::strings. Case-insensitive.
+     * 
+     * @param str1 - One of the std::strings to compare
+     * @param str2 - The other std::string to compare
+     * @return true if the strings are equal
+     * @return false if the strings are not equal
+     */
+    bool iequals(const std::string& str1, const std::string& str2);
+    
+    /**
      * @brief Resolves the current working directory.
      * 
      * Replaces the home directory prefix with - if applicable.

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -28,6 +28,16 @@ namespace cppsh {
         return line;
     }
 
+    bool iequals(const std::string& str1, const std::string& str2) {
+        if (str1.size() != str2.size()) return false;
+
+        return std::equal(str1.begin(), str1.end(), str2.begin(), [](char c1, char c2) {
+            //Cast to unsigned char value is not negative, which could result in an undefined behaviour
+            return std::tolower(static_cast<unsigned char >(c1)) == 
+                   std::tolower(static_cast<unsigned char>(c2));
+    });
+}
+
     std::string get_cwd() {
         char buffer[PATH_MAX];
 

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -14,6 +14,7 @@
 #include "dispatcher.hpp"
 #include "commands/commands.hpp"
 #include "commands/entry.hpp"
+#include "utils.hpp"
 #include <iostream>
 
 Dispatcher::Dispatcher() {
@@ -29,7 +30,7 @@ int Dispatcher::dispatch(const cppsh::Command& cmd, ShellContext& context) {
     if (cmd.args.empty()) return 0;
 
     for (const CommandEntry& entry : entries) {
-        if (entry.name == cmd.args[0]) {
+        if (cppsh::iequals(entry.name, cmd.args[0])) {
             return entry.handler(cmd, context);
         }
     }

--- a/tests/dispatcher_test.cpp
+++ b/tests/dispatcher_test.cpp
@@ -64,6 +64,13 @@ TEST_F(DispatcherTest, HelpReturnsZero) {
     EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
 }
 
+// heLP returns 0 (case insensitive test)
+TEST_F(DispatcherTest, HelpIReturnsZero) {
+    cppsh::Command cmd;
+    cmd.args = {"heLP"};
+    EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
+}
+
 // get_entries returns non-empty list
 TEST_F(DispatcherTest, GetEntriesNotEmpty) {
     EXPECT_FALSE(dispatcher.get_entries().empty());


### PR DESCRIPTION
- Implemented iequals() in utils.cpp to compare strings in a case insensitive manner
- Added cppsh::iequals() to Dispatcher::dispatch() to allow for case insensitive command dispatching
- Added an extra test in dispatcher_test.cpp to test for case insensitivity