### PR TITLE
feat: v0.2-alpha — external binaries, signal handling, case-insensitive dispatch, error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(cppsh
     src/dispatcher.cpp
     src/executor.cpp
     src/signal_handling.cpp
+    src/errors/shell_error.cpp
     lib/utils.cpp
     lib/parser.cpp
     ${COMMAND_FILES}
@@ -32,6 +33,7 @@ add_executable(tests
     src/dispatcher.cpp
     src/executor.cpp
     src/signal_handling.cpp
+    src/errors/shell_error.cpp
     ${BUILTIN_FILES}
     )
 target_link_libraries(tests PRIVATE GTest::gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(cppsh
     src/shell.cpp
     src/dispatcher.cpp
     src/executor.cpp
+    src/signal_handling.cpp
     lib/utils.cpp
     lib/parser.cpp
     ${COMMAND_FILES}
@@ -30,6 +31,7 @@ add_executable(tests
     lib/utils.cpp
     src/dispatcher.cpp
     src/executor.cpp
+    src/signal_handling.cpp
     ${BUILTIN_FILES}
     )
 target_link_libraries(tests PRIVATE GTest::gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(cppsh
     src/main.cpp
     src/shell.cpp
     src/dispatcher.cpp
+    src/executor.cpp
     lib/utils.cpp
     lib/parser.cpp
     ${COMMAND_FILES}
@@ -28,6 +29,7 @@ add_executable(tests
     lib/parser.cpp
     lib/utils.cpp
     src/dispatcher.cpp
+    src/executor.cpp
     ${BUILTIN_FILES}
     )
 target_link_libraries(tests PRIVATE GTest::gtest_main)

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ A Unix shell implementation in C++ supporting built-in commands, command dispatc
 ## Features
 
 - **Interactive prompt** — displays `user@hostname:~/path$` with home directory substitution
-- **Command dispatcher** — extensible, table-driven dispatch system with case-insensitive matching (planned)
+- **Command dispatcher** — extensible, table-driven dispatch system with case-insensitive matching
 - **Built-in commands** — `cd`, `exit`, `help`, `history`
+- **External binary execution** — runs any binary in `$PATH` via `fork` + `execvp`
+- **Signal handling** — `Ctrl+C` terminates the running command, `Ctrl+Z` suspends it
+- **Robust error handling** — structured error system with hex error codes for system errors
 - **Command history** — tracks all executed commands during the session
 - **Graceful EOF handling** — exits cleanly on `Ctrl+D`
-- **Unit tested** — parser and dispatcher covered with Google Test
+- **Unit tested** — parser, dispatcher and error handling covered with Google Test
 
 ---
 
@@ -40,8 +43,11 @@ make
 ### Run the shell
 
 ```bash
-make run
+make
+./build/cppsh
 ```
+
+> Run directly instead of `make run` to ensure signal handling works correctly.
 
 ### Run tests
 
@@ -76,6 +82,7 @@ cppsh/
 │   ├── include/                    # Internal shared headers
 │   │   ├── context.hpp             # ShellContext — shell runtime state
 │   │   ├── dispatcher.hpp          # Command dispatcher
+│   │   ├── executor.hpp            # External binary executor
 │   │   ├── shell.hpp               # Main shell loop
 │   │   └── icommand_registry.hpp   # ICommandRegistry interface
 │   ├── commands/
@@ -87,19 +94,26 @@ cppsh/
 │   │   │   └── history.cpp
 │   │   ├── entry.hpp               # CommandEntry — dispatch table entry
 │   │   └── commands.hpp            # Centralized builtin includes
-│   ├── dispatcher.cpp       
-│   ├── shell.cpp            
+│   ├── errors/
+│   │   ├── error_codes.hpp         # ShellErrorCode — hex error codes
+│   │   ├── shell_error.hpp         # ShellError — structured error class
+│   │   └── shell_error.cpp
+│   ├── dispatcher.cpp
+│   ├── executor.cpp
+│   ├── signal_handling.cpp         # SIGINT and SIGTSTP handlers
+│   ├── shell.cpp
 │   └── main.cpp                    # Entry point
 ├── include/                        # Public headers
-│   ├── parser.hpp                  # Input parser 
-│   ├── utils.hpp                   # Utility functions 
-│   └── command.hpp                 # Command struct 
+│   ├── parser.hpp                  # Input parser
+│   ├── utils.hpp                   # Utility functions
+│   └── command.hpp                 # Command struct
 ├── lib/                            # Public implementations
-│   ├── parser.cpp                  
-│   └── utils.cpp                  
+│   ├── parser.cpp
+│   └── utils.cpp
 ├── tests/
 │   ├── parser_test.cpp
-│   └── dispatcher_test.cpp
+│   ├── dispatcher_test.cpp
+│   └── error_test.cpp
 ├── docs/
 ├── CMakeLists.txt
 ├── Makefile
@@ -119,28 +133,52 @@ main.cpp
         ├── cppsh::Parser::parse()    # tokenizes input into Command
         └── Dispatcher::dispatch()    # routes Command to handler
               ├── builtin handler     # cd, exit, help, history
-              └── Executor (planned)  # fork + execvp for external binaries
+              └── Executor            # fork + execvp for external binaries
+                    └── ShellError    # structured error reporting
 ```
 
 The `Dispatcher` implements `ICommandRegistry`, allowing `ShellContext` to access the command registry without depending on a concrete implementation — following the Dependency Inversion principle.
 
 ---
 
+## Error Handling
+
+cppsh distinguishes between two categories of errors:
+
+**User errors** — plain language messages:
+```
+cd: /naoexiste: no such directory
+```
+
+**System errors** — hex error codes with OS context:
+```
+error[0x0100]: os error: 12 (cannot allocate memory)
+```
+
+Error codes follow a structured range:
+
+| Range | Category |
+|---|---|
+| `0x0000` – `0x00FF` | User errors |
+| `0x0100` – `0xFFFF` | System errors |
+
+---
+
 ## Roadmap
 
-### v0.1-alpha (current)
+### v0.1-alpha
 - ✅ Built-in commands: cd, exit, help, history
 - ✅ Command dispatcher
 - ✅ Command history
 - ✅ Interactive prompt
 
-### v0.2-alpha
-- Execute external binaries (fork + execvp)
-- Signal handling (Ctrl+C, Ctrl+Z)
-- Case-insensitive command dispatching
-- Robust error handling system
+### v0.2-alpha (current)
+- ✅ Execute external binaries (fork + execvp)
+- ✅ Signal handling (Ctrl+C, Ctrl+Z)
+- ✅ Case-insensitive command dispatching
+- ✅ Robust error handling system
 
-### v0.3-beta
+### v0.3-beta (WIP)
 - I/O Redirection (>, >>, <)
 - Pipes (|)
 - Background execution (&)
@@ -162,6 +200,7 @@ The `Dispatcher` implements `ICommandRegistry`, allowing `ShellContext` to acces
 ---
 
 ## Documentation
+
 For detailed technical information about the code architecture, design patterns, tests, etc. check the [Technical Manual](doc/technical_manual.md).
 
 ## Author

--- a/doc/technical_manual.md
+++ b/doc/technical_manual.md
@@ -1,6 +1,6 @@
 # cppsh — Technical Manual
 
-> Version: v0.1-alpha — covers the initial release of cppsh.
+> Version: v0.2-alpha — covers the second release of cppsh.
 
 ## Table of Contents
 
@@ -8,11 +8,14 @@
 2. [Main Loop](#main-loop)
 3. [Parser](#parser)
 4. [Dispatcher](#dispatcher)
-5. [Command Registry Interface](#command-registry-interface)
-6. [Shell Context](#shell-context)
-7. [Built-in Commands](#built-in-commands)
-8. [Utility Library](#utility-library)
-9. [Tests](#tests)
+5. [Executor](#executor)
+6. [Signal Handling](#signal-handling)
+7. [Error Handling](#error-handling)
+8. [Command Registry Interface](#command-registry-interface)
+9. [Shell Context](#shell-context)
+10. [Built-in Commands](#built-in-commands)
+11. [Utility Library](#utility-library)
+12. [Tests](#tests)
 
 ---
 
@@ -33,10 +36,13 @@ cppsh follows a layered architecture with clear separation of responsibilities:
      │ parse()      │  │ get_entries() │
      └──────────────┘  └──────┬────────┘
                               │
-              ┌───────────────┼───────────────┐
-              │               │               │
-         builtin_cd    builtin_help    builtin_history
-         builtin_exit
+              ┌───────────────┴───────────────┐
+              │                               │
+         builtin_cd                        Executor
+         builtin_help                    fork + execvp            
+         builtin_exit         
+         builtin_history              
+                        
 ```
 
 **Data flow:**
@@ -45,7 +51,8 @@ cppsh follows a layered architecture with clear separation of responsibilities:
 2. The input is recorded in `ShellContext::history`
 3. `cppsh::Parser::parse()` tokenizes the input into a `Command` struct
 4. `Dispatcher::dispatch()` looks up the command in its registry and calls the matching handler
-5. If no handler is found, an error is printed (executor planned for v0.2-alpha)
+5. If no builtin matches, the `Executor` forks a child process and runs the command via `execvp`
+6. If the command is not found, a `ShellError` is thrown and caught in `Shell::run()`
 
 ---
 
@@ -69,7 +76,7 @@ The `Shell` class owns the main REPL (Read-Eval-Print Loop) and holds all top-le
 
 #### `Shell()`
 
-Initializes the shell. Resolves the current username and hostname via `cppsh::get_username()` and `cppsh::get_hostname()`. Initializes `context` with a reference to `dispatcher` via initializer list — required because `ShellContext` holds a reference to `ICommandRegistry`.
+Initializes the shell. Resolves the current username and hostname via `cppsh::get_username()` and `cppsh::get_hostname()`. Initializes `context` with a reference to `dispatcher` via initializer list. Registers signal handlers via `handle_signal()`.
 
 #### `run()`
 
@@ -80,19 +87,12 @@ Main loop. On each iteration:
 - Skips blank lines
 - Records the input in `context.history`
 - Parses the input into a `Command` via `parser.parse()`
-- Dispatches the command via `dispatcher.dispatch()`
+- Dispatches the command via `dispatcher.dispatch()` inside a `try/catch` block
+- Catches `ShellError` and calls `e.print()`
 
 #### `print_prompt()`
 
 Prints the prompt in the format `user@hostname:~/path$ `. The current working directory is resolved via `get_cwd()`, which substitutes the `$HOME` prefix with `~` for a cleaner display.
-
-#### `get_cwd()` *(in `lib/utils`)*
-
-Calls `getcwd()` to obtain the current directory. If the path starts with the value of `$HOME`, replaces that prefix with `~`.
-
-#### `read_input()` *(in `lib/utils`)*
-
-Reads a full line from `stdin` using `std::getline`. Returns an empty string on EOF.
 
 ---
 
@@ -142,13 +142,123 @@ Initializes the `entries` vector with all registered built-in commands:
 
 #### `dispatch(const cppsh::Command& cmd, ShellContext& context)`
 
-Iterates `entries` and compares `cmd.args[0]` against each entry's `name`. On match, calls `entry.handler(cmd, context)` and returns its result. If no match is found, prints an error to `stderr` and returns `1`.
+Iterates `entries` and compares `cmd.args[0]` against each entry's `name` using `cppsh::iequals` for case-insensitive matching. On match, calls `entry.handler(cmd, context)` and returns its result.
+
+If no builtin matches, delegates to `executor.execute(cmd)`. If the executor returns `127` (command not found in `$PATH`), throws `ShellError(ShellErrorCode::COMMAND_NOT_FOUND)`.
 
 Returns `0` immediately if `cmd.args` is empty.
 
 #### `get_entries()`
 
-Returns a `const` reference to the internal `entries` vector. Implemented inline — used by `builtin_help` to list available commands.
+Returns a `const` reference to the internal `entries` vector. Used by `builtin_help` to list available commands.
+
+---
+
+## Executor
+
+**File:** `src/executor.cpp`
+
+### Class: `Executor`
+
+Responsible for running external binaries — any command not matched by the dispatcher as a builtin.
+
+#### `execute(const cppsh::Command& cmd)`
+
+1. Calls `fork()` to create a child process
+2. On `fork` failure, throws `ShellError(ShellErrorCode::FORK_FAILED)`
+3. In the child process:
+   - Calls `setpgrp()` to place the child in its own process group, isolating signal delivery
+   - Resets `SIGINT` and `SIGTSTP` to `SIG_DFL` so the child responds normally to signals
+   - Converts `cmd.args` to `char**` via `cppsh::to_vchar()`
+   - Calls `execvp()` — the `p` variant searches `$PATH` automatically
+   - If `execvp` returns, it failed — calls `exit(127)` (Unix convention for command not found)
+4. In the parent process:
+   - Waits for the child via `waitpid(c_pid, &status, WUNTRACED)`
+   - `WUNTRACED` allows the parent to detect when the child is suspended (`Ctrl+Z`)
+   - Returns the appropriate exit code based on how the child terminated:
+     - `WIFEXITED` — returns `WEXITSTATUS(status)`
+     - `WIFSIGNALED` — returns `0` (killed by signal, not a shell error)
+     - `WIFSTOPPED` — returns `0` (suspended by `Ctrl+Z`)
+
+---
+
+## Signal Handling
+
+**File:** `src/signal_handling.cpp`
+
+### `handle_signal()`
+
+Registers signal handlers for `SIGINT` and `SIGTSTP` using `sigaction`. Called once in `Shell::Shell()`.
+
+### `handle_sigint(int signum)`
+
+Called when `Ctrl+C` is pressed. The parent shell ignores `SIGINT` via `signal(SIGINT, SIG_IGN)`. The child process, having reset to `SIG_DFL` before `execvp`, is terminated normally.
+
+### `handle_sigtstp(int signum)`
+
+Called when `Ctrl+Z` is pressed. The parent shell ignores `SIGTSTP` via `signal(SIGTSTP, SIG_IGN)`. The child process, isolated in its own process group via `setpgrp()`, is suspended normally.
+
+> **Note:** Run the shell directly via `./build/cppsh` rather than `make run`. Running through `make` adds an extra process layer that interferes with process group isolation and signal delivery.
+
+---
+
+## Error Handling
+
+**Files:** `src/errors/error_codes.hpp`, `src/errors/shell_error.hpp`, `src/errors/shell_error.cpp`
+
+### Error Code Ranges
+
+| Range | Category |
+|---|---|
+| `0x0000` – `0x00FF` | User errors |
+| `0x0100` – `0xFFFF` | System errors |
+
+### `ShellErrorCode`
+
+```cpp
+enum class ShellErrorCode : int {
+    // User errors
+    COMMAND_NOT_FOUND = 0x0001,
+    INVALID_PATH      = 0x0002,
+    INVALID_ARGS      = 0x0003,
+
+    // System errors
+    FORK_FAILED       = 0x0100,
+    EXECVP_FAILED     = 0x0101,
+};
+```
+
+### Class: `ShellError`
+
+Wraps a `ShellErrorCode` with optional context — the command name, the invalid argument, and the correct usage string. Thrown at the point of failure and caught in `Shell::run()`.
+
+#### Members (private)
+
+| Member | Type | Description |
+|---|---|---|
+| `code` | `ShellErrorCode` | Error code |
+| `cmd` | `std::string` | Command that caused the error |
+| `arg` | `std::string` | Invalid argument passed to the command |
+| `usage` | `std::string` | Correct usage of the command |
+
+#### `print()`
+
+Determines the output format based on `is_system_error()`:
+
+**User error:**
+```
+cppsh: 'cd': invalid path '/naoexiste'
+```
+
+**System error:**
+```
+cppsh: error[0x0100]: 
+  --> os error: 12 (cannot allocate memory)
+```
+
+#### `is_system_error()` (private)
+
+Returns `true` if `static_cast<int>(code) >= 0x0100`.
 
 ---
 
@@ -162,7 +272,7 @@ Abstract interface that defines the contract for any command registry. Decouples
 
 #### `get_entries()`
 
-Pure virtual method. Returns a `const` reference to the list of `CommandEntry` objects. Must be implemented by any class that inherits from `ICommandRegistry`.
+Pure virtual method. Returns a `const` reference to the list of `CommandEntry` objects.
 
 #### `~ICommandRegistry()`
 
@@ -176,7 +286,7 @@ Virtual destructor — required to ensure correct destruction of derived classes
 
 ### Struct: `ShellContext`
 
-Holds the runtime state of the shell. Passed by reference to all command handlers, giving them access to shared state without global variables.
+Holds the runtime state of the shell. Passed by reference to all command handlers.
 
 #### Fields
 
@@ -184,8 +294,6 @@ Holds the runtime state of the shell. Passed by reference to all command handler
 |---|---|---|
 | `history` | `std::vector<std::string>` | List of commands executed during the session |
 | `registry` | `ICommandRegistry&` | Reference to the command registry (used by `help`) |
-
-`ShellContext` is initialized in `Shell::Shell()` via initializer list, receiving a reference to the `Dispatcher` instance (which implements `ICommandRegistry`).
 
 ---
 
@@ -199,7 +307,7 @@ All built-in commands share the same handler signature:
 int handler(const cppsh::Command& command, ShellContext& context);
 ```
 
-Returns `0` on success, `1` on error — following Unix convention.
+Returns `0` on success, throws `ShellError` on error.
 
 ### `builtin_exit`
 
@@ -211,13 +319,11 @@ Changes the current working directory using `chdir()`.
 
 - With no arguments — changes to `$HOME`, falling back to `/` if `HOME` is not set
 - With a path argument — changes to the specified path
-- On failure — prints an error message and returns `1`
-
-The path is passed directly to `chdir()` — the OS handles `.`, `..`, absolute and relative paths natively.
+- On failure — throws `ShellError(ShellErrorCode::INVALID_PATH, "cd", path)`
 
 ### `builtin_history`
 
-Iterates `context.history` and prints each entry with a 1-based index. Uses a range-based for loop with `const std::string&` to avoid unnecessary copies.
+Iterates `context.history` and prints each entry with a 1-based index.
 
 ### `builtin_help`
 
@@ -233,19 +339,27 @@ All utilities live in the `cppsh` namespace.
 
 ### `get_username()`
 
-Calls `getpwuid(getuid())` to retrieve the current user's username from the system password database. Falls back to `"user"` on failure.
+Calls `getpwuid(getuid())` to retrieve the current user's username. Falls back to `"user"` on failure.
 
 ### `get_hostname()`
 
-Calls `gethostname()` to retrieve the machine hostname. Falls back to `"localhost"` on failure. Uses `_POSIX_HOST_NAME_MAX` for the buffer size.
+Calls `gethostname()` to retrieve the machine hostname. Falls back to `"localhost"` on failure.
 
 ### `get_cwd()`
 
-Calls `getcwd()` to retrieve the current working directory. Substitutes the `$HOME` prefix with `~` if applicable. Returns `"?"` on failure.
+Calls `getcwd()` to retrieve the current working directory. Substitutes the `$HOME` prefix with `~`. Returns `"?"` on failure.
 
 ### `read_input()`
 
 Reads a line from `stdin` using `std::getline`. Returns an empty string on EOF.
+
+### `iequals(const std::string& a, const std::string& b)`
+
+Case-insensitive string comparison. Uses `std::equal` with a lambda that applies `std::tolower` (via `static_cast<unsigned char>`) to each character pair. Short-circuits on size mismatch.
+
+### `to_vchar(const std::vector<std::string>& v)`
+
+Converts a `std::vector<std::string>` to a `std::vector<char*>` terminated with `nullptr`, suitable for passing to `execvp`. Uses `const_cast<char*>` since `execvp` expects `char**` but does not modify the strings.
 
 ---
 
@@ -272,13 +386,23 @@ make test
 
 | Test | Description |
 |---|---|
-| `UnknownCommandReturnsError` | Unknown command returns `1` |
+| `UnknownCommandThrows` | Unknown command throws `ShellError` |
 | `EmptyCommandReturnsZero` | Empty `args` returns `0` |
 | `CdNoArgsReturnsZero` | `cd` with no arguments returns `0` |
 | `CdValidPathReturnsZero` | `cd /tmp` returns `0` |
-| `CdInvalidPathReturnsError` | Invalid path returns `1` |
+| `CdInvalidPathThrows` | Invalid path throws `ShellError` |
 | `HistoryEmptyReturnsZero` | `history` with empty history returns `0` |
 | `HistoryWithEntriesReturnsZero` | `history` with entries returns `0` |
 | `HelpReturnsZero` | `help` returns `0` |
+| `HelpIReturnsZero` | `heLP` returns `0` (case-insensitive) |
 | `GetEntriesNotEmpty` | Registry is not empty on initialization |
 | `GetEntriesContainsBuiltins` | Registry contains `cd`, `exit`, `help`, `history` |
+
+### `error_test.cpp`
+
+| Test | Description |
+|---|---|
+| `InvalidPathThrows` | `INVALID_PATH` throws `ShellError` |
+| `CommandNotFoundThrows` | `COMMAND_NOT_FOUND` throws `ShellError` |
+| `ForkFailedThrows` | `FORK_FAILED` throws `ShellError` |
+| `NoThrowOnSuccess` | Constructing `ShellError` does not throw |

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -24,6 +24,16 @@ namespace cppsh {
     std::string read_input();
 
     /**
+     * @brief Compares two std::strings. Case-insensitive.
+     * 
+     * @param str1 - One of the std::strings to compare
+     * @param str2 - The other std::string to compare
+     * @return true if the strings are equal
+     * @return false if the strings are not equal
+     */
+    bool iequals(const std::string& str1, const std::string& str2);
+    
+    /**
      * @brief Resolves the current working directory.
      * 
      * Replaces the home directory prefix with - if applicable.

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,8 +4,8 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.1
- * @date 2026-04-29
+ * @version 0.2.0
+ * @date 2026-05-13
  * 
  * @copyright Copyright (c) 2026
  * 
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace cppsh {
     /**
@@ -32,6 +33,14 @@ namespace cppsh {
      * @return false if the strings are not equal
      */
     bool iequals(const std::string& str1, const std::string& str2);
+
+    /**
+     * @brief Convert a vector of std::strings into a vector of char*
+     * 
+     * @param v the vector of std::strings
+     * @return std::vector<char*> the converted vector of char*
+     */
+    std::vector<char*> to_vchar(const std::vector<std::string>& v);
     
     /**
      * @brief Resolves the current working directory.

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -28,6 +28,16 @@ namespace cppsh {
         return line;
     }
 
+    bool iequals(const std::string& str1, const std::string& str2) {
+        if (str1.size() != str2.size()) return false;
+
+        return std::equal(str1.begin(), str1.end(), str2.begin(), [](char c1, char c2) {
+            //Cast to unsigned char value is not negative, which could result in an undefined behaviour
+            return std::tolower(static_cast<unsigned char >(c1)) == 
+                   std::tolower(static_cast<unsigned char>(c2));
+    });
+}
+
     std::string get_cwd() {
         char buffer[PATH_MAX];
 

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -4,8 +4,8 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.1
- * @date 2026-04-29
+ * @version 0.2.0
+ * @date 2026-05-13
  * 
  * @copyright Copyright (c) 2026
  * 
@@ -35,8 +35,19 @@ namespace cppsh {
             //Cast to unsigned char value is not negative, which could result in an undefined behaviour
             return std::tolower(static_cast<unsigned char >(c1)) == 
                    std::tolower(static_cast<unsigned char>(c2));
-    });
-}
+        });
+    }
+
+    std::vector<char*> to_vchar(const std::vector<std::string>& v) {
+        std::vector<char*> vchr;
+
+        for(size_t i = 0; i < v.size(); i++) {
+            vchr.push_back(const_cast<char*>(v[i].c_str()));
+        }
+        vchr.push_back(nullptr);
+
+        return vchr;
+    }
 
     std::string get_cwd() {
         char buffer[PATH_MAX];

--- a/src/commands/builtins/cd.cpp
+++ b/src/commands/builtins/cd.cpp
@@ -4,7 +4,7 @@
  *
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  *
- * @version 0.2.1
+ * @version 0.3.0
  * @date 2026-05-06
  *
  * @copyright Copyright (c) 2026
@@ -12,6 +12,8 @@
  */
 
 #include "cd.hpp"
+#include "errors/shell_error.hpp"
+
 #include <unistd.h>
 #include <iostream>
 #include <string>
@@ -30,8 +32,7 @@ int builtin_cd(const cppsh::Command& command, ShellContext& context) {
 
     // Change directory
     if (chdir(dir.c_str()) == -1) {
-        std::cout << "Couldn't find the directory '" << dir << "'"  << std::endl;
-        return 1;
+        throw ShellError(ShellErrorCode::INVALID_PATH, command.args[0], dir);
     }
 
    return 0;

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -14,6 +14,7 @@
 #include "dispatcher.hpp"
 #include "commands/commands.hpp"
 #include "commands/entry.hpp"
+#include "utils.hpp"
 #include <iostream>
 
 Dispatcher::Dispatcher() {
@@ -29,7 +30,7 @@ int Dispatcher::dispatch(const cppsh::Command& cmd, ShellContext& context) {
     if (cmd.args.empty()) return 0;
 
     for (const CommandEntry& entry : entries) {
-        if (entry.name == cmd.args[0]) {
+        if (cppsh::iequals(entry.name, cmd.args[0])) {
             return entry.handler(cmd, context);
         }
     }

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -4,7 +4,7 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.4.0
+ * @version 0.5.0
  * @date 2026-05-03
  * 
  * @copyright Copyright (c) 2026
@@ -12,6 +12,7 @@
  */
 
 #include "dispatcher.hpp"
+#include "errors/shell_error.hpp"
 #include "commands/commands.hpp"
 #include "commands/entry.hpp"
 #include "utils.hpp"
@@ -30,14 +31,14 @@ int Dispatcher::dispatch(const cppsh::Command& cmd, ShellContext& context) {
     if (cmd.args.empty()) return 0;
 
     for (const CommandEntry& entry : entries) {
-        if (cppsh::iequals(entry.name, cmd.args[0])) {
+        if (cppsh::iequals(entry.name, cmd.args[0]))
             return entry.handler(cmd, context);
-        }
     }
 
-    if (executor.execute(cmd)) {
-        std::cerr << "Unknown command: '" << cmd.args[0] << "'" << std::endl;
-    }
-    return 1;
+    int res = executor.execute(cmd);
+    if (res == 127)
+        throw ShellError(ShellErrorCode::COMMAND_NOT_FOUND, cmd.args[0]);
+
+    return res;
 }
 

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -4,7 +4,7 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.3.0
+ * @version 0.4.0
  * @date 2026-05-03
  * 
  * @copyright Copyright (c) 2026
@@ -35,8 +35,9 @@ int Dispatcher::dispatch(const cppsh::Command& cmd, ShellContext& context) {
         }
     }
 
-    // TODO: executor
-    std::cerr << "Unknown command: '" << cmd.args[0] << "'" << std::endl;
+    if (executor.execute(cmd)) {
+        std::cerr << "Unknown command: '" << cmd.args[0] << "'" << std::endl;
+    }
     return 1;
 }
 

--- a/src/errors/error_codes.hpp
+++ b/src/errors/error_codes.hpp
@@ -1,0 +1,24 @@
+/**
+ * @file error_codes.hpp
+ * @brief Contains definition of the error codes and their hexa value, in a ShellErrorCode enum class
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com) 
+ * @version 0.1
+ * 
+ * @date 2026-05-15
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+ enum class ShellErrorCode : int {
+    //User errors (0x0000 - 0x00FF)
+    COMMAND_NOT_FOUND  = 0x0000,
+    INVALID_PATH       = 0x0001,
+    INVALID_ARGS       = 0x0002,
+
+
+    //System errors (0x0100 - 0xFFFF)
+    FORK_FAILED        = 0x0100,
+    EXECVP_FAILED      = 0x0101,
+ };

--- a/src/errors/shell_error.cpp
+++ b/src/errors/shell_error.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file shell_error.cpp
+ * @brief Implementation for shell_error.hpp
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com) 
+ * 
+ * @version 0.1
+ * @date 2026-05-15
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "shell_error.hpp"
+#include <iostream>
+#include <cerrno>
+#include <iomanip>
+
+ShellError::ShellError(ShellErrorCode code, std::string cmd, std::string arg, std::string usage) 
+    : code(code), cmd(cmd), arg(arg), usage(usage) {}
+
+void ShellError::print(){
+    if (is_system_error()){
+        std::cerr << "cppsh: error[0x" << std::hex << std::setw(4) << std::setfill('0') 
+              << static_cast<int>(code) << "]: ";
+        std::cerr << "os error: " << errno << " (" << strerror(errno) << ")" << std::endl;
+        return;
+    }
+
+    //User error
+    switch(code){
+        case ShellErrorCode::INVALID_PATH:
+            std::cerr << "cppsh: '" << cmd << "': invalid path '/" << arg << "'" << std::endl; 
+            break;
+        case ShellErrorCode::COMMAND_NOT_FOUND:
+            std::cerr << "cppsh: '" << cmd << "': unknown command" << std::endl;
+            break;
+        case ShellErrorCode::INVALID_ARGS:
+            std::cerr << "cppsh: '" << cmd << "': invalid arguments '" << arg << "'" << std::endl; 
+            std::cerr << "usage: " << usage << std::endl;   
+            break;
+        default:
+            std::cerr << "cppsh: An unexpected error has occurred." << std::endl;
+    }
+}
+
+bool ShellError::is_system_error(){
+    return static_cast<int>(code) >= 0x0100;
+}

--- a/src/errors/shell_error.cpp
+++ b/src/errors/shell_error.cpp
@@ -21,7 +21,7 @@ ShellError::ShellError(ShellErrorCode code, std::string cmd, std::string arg, st
 
 void ShellError::print(){
     if (is_system_error()){
-        std::cerr << "cppsh: error[0x" << std::hex << std::setw(4) << std::setfill('0') 
+        std::cerr << "error[0x" << std::hex << std::setw(4) << std::setfill('0') 
               << static_cast<int>(code) << "]: ";
         std::cerr << "os error: " << errno << " (" << strerror(errno) << ")" << std::endl;
         return;
@@ -30,17 +30,17 @@ void ShellError::print(){
     //User error
     switch(code){
         case ShellErrorCode::INVALID_PATH:
-            std::cerr << "cppsh: '" << cmd << "': invalid path '/" << arg << "'" << std::endl; 
+            std::cerr << cmd << ": /" << arg << ": No such directory" << std::endl; 
             break;
         case ShellErrorCode::COMMAND_NOT_FOUND:
-            std::cerr << "cppsh: '" << cmd << "': unknown command" << std::endl;
+            std::cerr << cmd << ": Unknown command" << std::endl;
             break;
         case ShellErrorCode::INVALID_ARGS:
-            std::cerr << "cppsh: '" << cmd << "': invalid arguments '" << arg << "'" << std::endl; 
-            std::cerr << "usage: " << usage << std::endl;   
+            std::cerr << cmd << ": '" << arg << "' Invalid arguments" << std::endl; 
+            std::cerr << "Usage: " << usage << std::endl;   
             break;
         default:
-            std::cerr << "cppsh: An unexpected error has occurred." << std::endl;
+            std::cerr << "An unexpected error has occurred." << std::endl;
     }
 }
 

--- a/src/errors/shell_error.hpp
+++ b/src/errors/shell_error.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file shell_error.hpp
+ * @brief Includes definition for ShellError class, which handles shell error I/O
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com)
+ * @version 0.1
+ * 
+ * @date 2026-05-15
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "error_codes.hpp"
+#include <string>
+
+class ShellError {
+public:
+    ShellError(ShellErrorCode code, std::string cmd = "", std::string arg = "", std::string usage = "");
+    /**
+     * @brief Prints the error message in the shell.
+     */
+    void print();
+
+private:
+    ShellErrorCode code;    //Error Code
+    std::string cmd;        //Command that caused the error
+    std::string arg;        //Invalid argument passed to the command
+    std::string usage;      //Correct usage of the command
+
+    /**
+     * @brief Checks if the error code is a system error
+     * 
+     * @return true if the error is a system error
+     * @return false if the error is a user error
+     */
+    bool is_system_error();
+};

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -15,6 +15,7 @@
 #include "utils.hpp"
 #include <unistd.h>
 #include <iostream>
+#include <csignal>
 
 int Executor::execute(const cppsh::Command& cmd) {
     if (cmd.args.empty()) return 0;
@@ -28,11 +29,23 @@ int Executor::execute(const cppsh::Command& cmd) {
     else if (c_pid > 0) {
         //Parent process
         int status;
-        waitpid(c_pid, &status, 0); // wait for child to end
-        return WEXITSTATUS(status);
+        waitpid(c_pid, &status, WUNTRACED); // wait for child to end
+
+        if (WIFEXITED(status)) {
+            return WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            return 0;
+        } else if (WIFSTOPPED(status)) {
+            return 0;
+        }
+        return 0;
     }
     else {
         //Child process
+        setpgrp();
+        signal(SIGINT, SIG_DFL); //Reset signal behaviour to default in child process
+        signal(SIGTSTP, SIG_DFL);
+
         std::vector<char*> argv = cppsh::to_vchar(cmd.args);
 
         //.data() converts std::vector<char*> into char**

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -4,7 +4,7 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.1.0
+ * @version 0.2.0
  * @date 2026-05-13
  * 
  * @copyright Copyright (c) 2026
@@ -12,6 +12,8 @@
  */
 
 #include "include/executor.hpp"
+#include "errors/shell_error.hpp"
+
 #include "utils.hpp"
 #include <unistd.h>
 #include <iostream>
@@ -22,10 +24,8 @@ int Executor::execute(const cppsh::Command& cmd) {
 
     pid_t c_pid = fork();
 
-    if (c_pid == -1) {
-        perror("fork");
-        return -1;
-    }
+    if (c_pid == -1) 
+        throw ShellError(ShellErrorCode::FORK_FAILED);
     else if (c_pid > 0) {
         //Parent process
         int status;
@@ -52,6 +52,6 @@ int Executor::execute(const cppsh::Command& cmd) {
         execvp(cmd.args[0].c_str(), argv.data());
 
         //If the process reaches here, execvp failed
-        exit(0);
+        exit(127);
     }
 }

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -1,0 +1,44 @@
+/**
+ * @file executor.cpp
+ * @brief Implementation for executor.hpp
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com)
+ * 
+ * @version 0.1.0
+ * @date 2026-05-13
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "include/executor.hpp"
+#include "utils.hpp"
+#include <unistd.h>
+#include <iostream>
+
+int Executor::execute(const cppsh::Command& cmd) {
+    if (cmd.args.empty()) return 0;
+
+    pid_t c_pid = fork();
+
+    if (c_pid == -1) {
+        perror("fork");
+        return -1;
+    }
+    else if (c_pid > 0) {
+        //Parent process
+        int status;
+        waitpid(c_pid, &status, 0); // wait for child to end
+        return WEXITSTATUS(status);
+    }
+    else {
+        //Child process
+        std::vector<char*> argv = cppsh::to_vchar(cmd.args);
+
+        //.data() converts std::vector<char*> into char**
+        execvp(cmd.args[0].c_str(), argv.data());
+
+        //If the process reaches here, execvp failed
+        exit(0);
+    }
+}

--- a/src/include/dispatcher.hpp
+++ b/src/include/dispatcher.hpp
@@ -8,7 +8,7 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.3.0
+ * @version 0.4.0
  * @date 2026-05-07
  * 
  * @copyright Copyright (c) 2026
@@ -19,6 +19,7 @@
 
 #include "command.hpp"
 #include "icommand_registry.hpp"
+#include "executor.hpp"
 #include <vector>
 
 class Dispatcher : public ICommandRegistry {
@@ -41,6 +42,7 @@ class Dispatcher : public ICommandRegistry {
         inline const std::vector<CommandEntry>& get_entries() const override { return entries; }
 
     private:
+        Executor executor;
         std::vector<CommandEntry> entries;
 
 };

--- a/src/include/executor.hpp
+++ b/src/include/executor.hpp
@@ -1,0 +1,31 @@
+/**
+ * @file executor.hpp
+ *
+ * @brief Declaration for the command executor.
+ * 
+ * The executor receives a Command, searches for the command, 
+ * and if the command is found, forks a new process and executes the command via execvp().
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com)
+ * 
+ * @version 0.1.0
+ * @date 2026-05-13
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "command.hpp"
+#include "context.hpp"
+
+class Executor {
+    public:
+        /**
+         * @brief Searches for an external command, and if the command is found, fork a new process
+         * and execute it via execvp().
+         * 
+         * @param cmd The command input
+         * @return int Status code
+         */
+        int execute(const cppsh::Command& cmd);
+};

--- a/src/include/signal_handling.hpp
+++ b/src/include/signal_handling.hpp
@@ -1,0 +1,17 @@
+/**
+ * @file signal_handling.hpp
+ * @brief Contains the definition of the functions that handle signals
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com)
+ * 
+ * @version 0.1
+ * @date 2026-05-14
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+*/
+
+/**
+ * @brief Function to handle all signals.
+ */
+void handle_signal();

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -4,7 +4,7 @@
  * 
  * @author Filipe Paredes (filipeparedes3@gmail.com)
  * 
- * @version 0.4.0
+ * @version 0.5.0
  * @date 2026-04-29
  * 
  * @copyright Copyright (c) 2026
@@ -16,6 +16,7 @@
 #include "parser.hpp"
 #include "dispatcher.hpp"
 #include "signal_handling.hpp"
+#include "errors/shell_error.hpp"
 
 #include <iostream>
 #include <string>
@@ -52,7 +53,12 @@ void Shell::run() {
         //Parse input into Command-type obj
         cppsh::Command cmd = parser.parse(input);
 
-        dsptchr.dispatch(cmd, context);
+        try {
+            dsptchr.dispatch(cmd, context);
+        } catch (ShellError& e) {
+            e.print();
+        }
+
     }
 }
 

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -15,6 +15,7 @@
 #include "utils.hpp"
 #include "parser.hpp"
 #include "dispatcher.hpp"
+#include "signal_handling.hpp"
 
 #include <iostream>
 #include <string>
@@ -26,6 +27,7 @@
 Shell::Shell() : context(dsptchr){
     m_hostname = cppsh::get_hostname();
     m_user = cppsh::get_username();
+    handle_signal();
 }
 
 void Shell::run() {

--- a/src/signal_handling.cpp
+++ b/src/signal_handling.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file signal_handling.cpp
+ * @brief Implementation for signal_handling.hpp, as well as some private functions for specific signals
+ * 
+ * @author Filipe Paredes (filipeparedes3@gmail.com)
+ * @version 0.1
+ * @date 2026-05-14
+ * 
+ * @copyright Copyright (c) 2026
+ * 
+ */
+
+#include "include/signal_handling.hpp"
+
+#include <csignal>
+#include <unistd.h>
+
+/**
+  * @brief Private function
+  * 
+  * Handles SIGINT, which is triggered when pressing Ctrl+C
+  * 
+  * The child process is immediately terminated.
+  * 
+  * @param signum The signal number
+  */
+void handle_sigint(int signum) {
+    signal(SIGINT, SIG_IGN); //parent process ignores signal
+    write(STDOUT_FILENO, "\r\033[K", 4); //hide ^C
+}
+
+
+/**
+ * @brief Private function
+ * 
+ * Handles SIGTSTP, which is triggered when pressing Ctrl+Z
+ * 
+ * The child process is suspended and sent to background.
+ * 
+ * @param signum The signal number
+ */
+void handle_sigtstp(int signum) {
+    signal(SIGTSTP, SIG_IGN); //parent process ignores signal
+    write(STDOUT_FILENO, "\r\033[K", 4); //hide ^Z
+}
+
+void handle_signal() {
+    struct sigaction sa_int;
+    sa_int.sa_handler = handle_sigint;
+    sigemptyset(&sa_int.sa_mask);
+    sa_int.sa_flags = 0;
+    sigaction(SIGINT, &sa_int, nullptr);
+
+    struct sigaction sa_tstp;
+    sa_tstp.sa_handler = handle_sigtstp;
+    sigemptyset(&sa_tstp.sa_mask);
+    sa_tstp.sa_flags = 0;
+    sigaction(SIGTSTP, &sa_tstp, nullptr);
+}

--- a/tests/dispatcher_test.cpp
+++ b/tests/dispatcher_test.cpp
@@ -64,6 +64,13 @@ TEST_F(DispatcherTest, HelpReturnsZero) {
     EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
 }
 
+// heLP returns 0 (case insensitive test)
+TEST_F(DispatcherTest, HelpIReturnsZero) {
+    cppsh::Command cmd;
+    cmd.args = {"heLP"};
+    EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
+}
+
 // get_entries returns non-empty list
 TEST_F(DispatcherTest, GetEntriesNotEmpty) {
     EXPECT_FALSE(dispatcher.get_entries().empty());

--- a/tests/dispatcher_test.cpp
+++ b/tests/dispatcher_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "dispatcher.hpp"
+#include "errors/shell_error.hpp"
 #include "context.hpp"
 
 class DispatcherTest : public ::testing::Test {
@@ -8,11 +9,11 @@ protected:
     ShellContext context{dispatcher};
 };
 
-// Unknown command returns error code
-TEST_F(DispatcherTest, UnknownCommandReturnsError) {
+// Unknown command throws ShellError
+TEST_F(DispatcherTest, UnknownCommandThrows) {
     cppsh::Command cmd;
     cmd.args = {"unknowncommand"};
-    EXPECT_EQ(dispatcher.dispatch(cmd, context), 1);
+    EXPECT_THROW(dispatcher.dispatch(cmd, context), ShellError);
 }
 
 // Empty command returns 0
@@ -21,11 +22,11 @@ TEST_F(DispatcherTest, EmptyCommandReturnsZero) {
     EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
 }
 
-// cd with no arguments returns 0
-TEST_F(DispatcherTest, CdNoArgsReturnsZero) {
+// cd with invalid path throws ShellError
+TEST_F(DispatcherTest, CdInvalidPathThrows) {
     cppsh::Command cmd;
-    cmd.args = {"cd"};
-    EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
+    cmd.args = {"cd", "/this/path/does/not/exist"};
+    EXPECT_THROW(dispatcher.dispatch(cmd, context), ShellError);
 }
 
 // cd with valid path returns 0
@@ -33,13 +34,6 @@ TEST_F(DispatcherTest, CdValidPathReturnsZero) {
     cppsh::Command cmd;
     cmd.args = {"cd", "/tmp"};
     EXPECT_EQ(dispatcher.dispatch(cmd, context), 0);
-}
-
-// cd with invalid path returns error
-TEST_F(DispatcherTest, CdInvalidPathReturnsError) {
-    cppsh::Command cmd;
-    cmd.args = {"cd", "/this/path/does/not/exist"};
-    EXPECT_EQ(dispatcher.dispatch(cmd, context), 1);
 }
 
 // history with empty history returns 0

--- a/tests/error_test.cpp
+++ b/tests/error_test.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include "shell_error.hpp"
+
+class ShellErrorTest : public ::testing::Test {};
+
+// ShellError is thrown and caught correctly
+TEST_F(ShellErrorTest, InvalidPathThrows) {
+    EXPECT_THROW(
+        throw ShellError(ShellErrorCode::INVALID_PATH, "cd", "/naoexiste"),
+        ShellError
+    );
+}
+
+TEST_F(ShellErrorTest, CommandNotFoundThrows) {
+    EXPECT_THROW(
+        throw ShellError(ShellErrorCode::COMMAND_NOT_FOUND, "sleeep"),
+        ShellError
+    );
+}
+
+TEST_F(ShellErrorTest, ForkFailedThrows) {
+    EXPECT_THROW(
+        throw ShellError(ShellErrorCode::FORK_FAILED),
+        ShellError
+    );
+}
+
+// ShellError is not thrown when no error
+TEST_F(ShellErrorTest, NoThrowOnSuccess) {
+    EXPECT_NO_THROW(
+        ShellError(ShellErrorCode::INVALID_PATH, "cd", "/tmp")
+    );
+}


### PR DESCRIPTION
### Summary
This PR closes the v0.2-alpha milestone, introducing four major features to cppsh.

### Changes
External Binary Execution

Added Executor class responsible for running any binary in $PATH
Uses fork + execvp to spawn child processes
Parent waits via waitpid with WUNTRACED to detect both termination and suspension
Child placed in its own process group via setpgrp() for correct signal isolation
Exit code 127 used to distinguish "command not found" from "command failed"

### Signal Handling

Added signal_handling.cpp with handle_signal(), handle_sigint() and handle_sigtstp()
SIGINT (Ctrl+C) — parent ignores, child terminates normally
SIGTSTP (Ctrl+Z) — parent ignores, child suspended normally
Handlers registered once in Shell::Shell() via sigaction

### Case-Insensitive Command Dispatching

Added cppsh::iequals() to utils for case-insensitive string comparison
Dispatcher uses iequals for all command lookups

### Robust Error Handling

Added ShellErrorCode enum class with hex error codes
User errors (0x0000–0x00FF) — plain language output
System errors (0x0100–0xFFFF) — hex code + OS errno context
ShellError thrown at point of failure, caught in Shell::run()
Updated all builtins and executor to throw ShellError instead of returning error codes

### Tests

Updated dispatcher_test.cpp — unknown command and invalid path now expect ShellError
Added error_test.cpp — covers ShellError construction and throw behaviour

### Documentation

Updated README and Technical Manual to reflect all v0.2-alpha changes